### PR TITLE
feat(compiler): rename import from pwc

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -5,7 +5,7 @@ module.exports = {
   coveragePathIgnorePatterns: ['<rootDir>/node_modules/'],
   roots: ['<rootDir>/packages'],
   testPathIgnorePatterns: ['/node_modules/', '/cjs/', '/esm/', '/es2017/', '/dist/', '.d.ts'],
-  testMatch: ['**/__tests__/**/*.[jt]s?(x)', '**/?(*.)+(spec|test).[jt]s?(x)'],
+  testMatch: ['**/__tests__/**/*.(spec|test).[jt]s?(x)'],
   testEnvironment: 'jsdom',
   transform: {
     '\\.(js|ts|jsx|tsx)$': 'babel-jest',

--- a/packages/pwc-compiler/__tests__/compileScript.test.ts
+++ b/packages/pwc-compiler/__tests__/compileScript.test.ts
@@ -1,6 +1,6 @@
 import { parse, compileScript } from '../src';
 
-const simpeComponent = `
+const simpleComponent = `
 <template>
   <p>{{this.#text}}</p>
 </template>
@@ -16,72 +16,6 @@ const noTemplateComponent = `
     #text = '';
   }
 </script>`;
-
-const mixNormalPropertyComponent = `
-<template>
-  <p>{{this.#text}}</p>
-</template>
-<script>
-  export default class CustomElement extends HTMLElement {
-    #text = '';
-    data = {};
-  }
-</script>
-`;
-
-const useObjectPropertyComponent = `
-<template>
-  <p>{{this.data.name}}</p>
-  <p>{{this.arr[0]}}</p>
-  <p>{{this.nestedData.obj1.obj2.age}}</p>
-</template>
-<script>
-  export default class CustomElement extends HTMLElement {
-    data = {};
-    arr = [];
-    nestedData = {
-      obj1: {
-        obj2: {
-          age: 10
-        }
-      }
-    }
-  }
-</script>
-`;
-
-const useOutsideVariableComponent = `
-<template>
-  <p>{{outsideName}}</p>
-  <p>{{this.insideName}}</p>
-</template>
-<script>
-  import outsideName from './data';
-  export default class CustomElement extends HTMLElement {
-    insideName = '';
-  }
-</script>
-`;
-
-const pureComponent = `
-<template>
-  <p>hello</p>
-</template>
-<script>
-export default class CustomElement extends HTMLElement {}
-</script>`;
-
-const definedComponent = `
-<template>
-  <p>hello</p>
-</template>
-<script>
-import { customElement } from 'pwc';
-
-@customElement('custom-element')
-export default class CustomElement extends HTMLElement {}
-</script>
-`;
 
 const multipleKindsOfUsingBindingsComponent = `
 <template>
@@ -124,25 +58,8 @@ const multipleKindsOfUsingBindingsComponent = `
 </script>`;
 
 describe('compileScript', () => {
-  test('It should inject pwc', () => {
-    const { descriptor } = parse(simpeComponent);
-    const result = compileScript(descriptor);
-
-    expect(result.content).toContain(`import { customElement, reactive } from \"pwc\";`);
-  });
-
-  test('It should inject decorators', () => {
-    const { descriptor } = parse(simpeComponent);
-    const result = compileScript(descriptor);
-
-    expect(result.content).toContain(`@customElement("custom-element")
-export default class CustomElement extends HTMLElement {
-  @reactive
-  accessor #text = '';`);
-  });
-
   test('It should inject template getter method', () => {
-    const { descriptor } = parse(simpeComponent);
+    const { descriptor } = parse(simpleComponent);
     const result = compileScript(descriptor);
 
     expect(result.content).toContain(`get template() {
@@ -157,115 +74,24 @@ export default class CustomElement extends HTMLElement {
     expect(result.content).not.toContain('get template()');
   });
 
-  test('It should not add @reactive decorator to normal property', () => {
-    const { descriptor } = parse(mixNormalPropertyComponent);
-    const result = compileScript(descriptor);
-
-    expect(result.content).toEqual(`import { customElement, reactive } from "pwc";
-@customElement("custom-element")
-export default class CustomElement extends HTMLElement {
-  @reactive
-  accessor #text = '';
-  data = {};
-
-  get template() {
-    return ["\\n  <p><!--?pwc_t--></p>\\n", [this.#text]];
-  }
-
-}`);
-  });
-
-  test('It should add @reactive decorator to object property', () => {
-    const { descriptor } = parse(useObjectPropertyComponent);
-    const result = compileScript(descriptor);
-
-    expect(result.content).toEqual(`import { customElement, reactive } from "pwc";
-@customElement("custom-element")
-export default class CustomElement extends HTMLElement {
-  @reactive
-  accessor data = {};
-  @reactive
-  accessor arr = [];
-  @reactive
-  accessor nestedData = {
-    obj1: {
-      obj2: {
-        age: 10
-      }
-    }
-  };
-
-  get template() {
-    return ["\\n  <p><!--?pwc_t--></p>\\n  <p><!--?pwc_t--></p>\\n  <p><!--?pwc_t--></p>\\n", [this.data.name, this.arr[0], this.nestedData.obj1.obj2.age]];
-  }
-
-}`);
-  });
-
-  test('It should not add @reactive decorator to outside data', () => {
-    const { descriptor } = parse(useOutsideVariableComponent);
-    const result = compileScript(descriptor);
-
-    expect(result.content).toEqual(`import { customElement, reactive } from "pwc";
-import outsideName from './data';
-@customElement("custom-element")
-export default class CustomElement extends HTMLElement {
-  @reactive
-  accessor insideName = '';
-
-  get template() {
-    return ["\\n  <p><!--?pwc_t--></p>\\n  <p><!--?pwc_t--></p>\\n", [outsideName, this.insideName]];
-  }
-
-}`);
-  });
-
-  test('It should not import pwc with pure component', () => {
-    const { descriptor } = parse(pureComponent);
-    const result = compileScript(descriptor);
-
-    expect(result.content).toEqual(`import { customElement } from \"pwc\";
-@customElement(\"custom-element\")
-export default class CustomElement extends HTMLElement {
-  get template() {
-    return [\"\\n  <p>hello</p>\\n\", []];
-  }
-
-}`);
-  });
-
-  test('It should not import customElement again with defined component', () => {
-    const { descriptor } = parse(definedComponent);
-    const result = compileScript(descriptor);
-
-    expect(result.content).toEqual(`import { customElement } from 'pwc';
-@customElement('custom-element')
-export default class CustomElement extends HTMLElement {
-  get template() {
-    return [\"\\n  <p>hello</p>\\n\", []];
-  }
-
-}`);
-  });
-
   test('It should handle multiple kinds of bindings', () => {
     const { descriptor } = parse(multipleKindsOfUsingBindingsComponent);
     const result = compileScript(descriptor);
 
-    expect(result.content).toEqual(`import { customElement, reactive } from "pwc";
-@customElement("custom-element")
+    expect(result.content).toEqual(`import { customElement as __customElement, reactive as __reactive } from "pwc";
+@__customElement("custom-element")
 export default class CustomElement extends HTMLElement {
-  @reactive
+  @__reactive
   accessor #data1 = '';
-  @reactive
+  @__reactive
   accessor #data2 = {
     name1: 'pwc'
   };
-  @reactive
+  @__reactive
   accessor data3 = {
     arr1: []
   };
-  @reactive
+  @__reactive
   accessor data4 = {
     obj1: {
       name2: 'pwc'

--- a/packages/pwc-compiler/__tests__/transforms/components.ts
+++ b/packages/pwc-compiler/__tests__/transforms/components.ts
@@ -1,0 +1,64 @@
+export const basicComponent = `
+<template>
+  <p>{{this.#name}}</p>
+</template>
+<script>
+export default class CustomElement extends HTMLElement {
+  #name = '';
+}
+</script>
+`;
+
+export const useCustomElementComponent = `
+<template>
+  <p>hello</p>
+</template>
+<script>
+import { customElement } from 'pwc';
+
+@customElement('custom-element')
+export default class CustomElement extends HTMLElement {}
+</script>
+`;
+
+export const useReactiveComponent = `
+<template>
+  <p>hello</p>
+</template>
+<script>
+import { reactive } from 'pwc';
+
+export default class CustomElement extends HTMLElement {
+  @reactive
+  accessor name = '';
+}
+</script>
+`;
+
+export const useReactiveWithAutoAddReactiveComponent = `
+<template>
+  <p>{{this.#name}}</p>
+</template>
+<script>
+import { reactive } from 'pwc';
+export default class CustomElement extends HTMLElement {
+  #name = '';
+  @reactive
+  accessor data = '';
+}
+</script>
+`;
+
+export const reactiveHasBeenReactiveDecoratedManuallyComponent = `
+<template>
+  <p>{{this.#name}}</p>
+</template>
+<script>
+import { reactive } from 'pwc';
+export default class CustomElement extends HTMLElement {
+  @reactive
+  accessor #name = '';
+}
+</script>
+`;
+

--- a/packages/pwc-compiler/__tests__/transforms/customElement.test.ts
+++ b/packages/pwc-compiler/__tests__/transforms/customElement.test.ts
@@ -1,0 +1,36 @@
+import { parse, compileScript } from '../../src';
+import { basicComponent, useCustomElementComponent } from './components';
+
+describe('customElement decorator', () => {
+  test('It should add customElement decorator', () => {
+    const { descriptor } = parse(basicComponent);
+    const result = compileScript(descriptor);
+
+    expect(result.content).toEqual(`import { customElement as __customElement, reactive as __reactive } from \"pwc\";
+@__customElement("custom-element")
+export default class CustomElement extends HTMLElement {
+  @__reactive
+  accessor #name = '';
+
+  get template() {
+    return ["\\n  <p><!--?pwc_t--></p>\\n", [this.#name]];
+  }
+
+}`);
+  });
+
+  test('It should not add customElement decorator if there is already customElement manually', () => {
+    const { descriptor } = parse(useCustomElementComponent);
+    const result = compileScript(descriptor);
+
+    expect(result.content).toEqual(`import { customElement } from 'pwc';
+@customElement('custom-element')
+export default class CustomElement extends HTMLElement {
+  get template() {
+    return ["\\n  <p>hello</p>\\n", []];
+  }
+
+}`);
+  });
+
+});

--- a/packages/pwc-compiler/__tests__/transforms/injectImportPWC.test.ts
+++ b/packages/pwc-compiler/__tests__/transforms/injectImportPWC.test.ts
@@ -1,0 +1,33 @@
+import { parse, compileScript } from '../../src';
+import { basicComponent, useCustomElementComponent, useReactiveComponent, useReactiveWithAutoAddReactiveComponent } from './components';
+
+describe('injectImportPWC', () => {
+  test('It should inject pwc', () => {
+    const { descriptor } = parse(basicComponent);
+    const result = compileScript(descriptor);
+
+    expect(result.content).toContain(`import { customElement as __customElement, reactive as __reactive } from \"pwc\";`);
+  });
+
+  test('It should not inject import customElement from pwc when imported customElement manually', () => {
+    const { descriptor } = parse(useCustomElementComponent);
+    const result = compileScript(descriptor);
+
+    expect(result.content).toContain(`import { customElement } from 'pwc';`);
+  });
+
+  test('It should not inject import reactive from pwc when there is no reactive variable in template', () => {
+    const { descriptor } = parse(useReactiveComponent);
+    const result = compileScript(descriptor);
+
+    expect(result.content).toContain(`import { reactive, customElement as __customElement } from 'pwc';`);
+  });
+
+
+  test('It should inject import reactive from pwc even if there is reactive imported manually', () => {
+    const { descriptor } = parse(useReactiveWithAutoAddReactiveComponent);
+    const result = compileScript(descriptor);
+
+    expect(result.content).toContain(`import { reactive, customElement as __customElement, reactive as __reactive } from 'pwc';`);
+  });
+});

--- a/packages/pwc-compiler/__tests__/transforms/reactive.test.ts
+++ b/packages/pwc-compiler/__tests__/transforms/reactive.test.ts
@@ -1,0 +1,191 @@
+import { parse, compileScript } from '../../src';
+import { useReactiveComponent, useReactiveWithAutoAddReactiveComponent, reactiveHasBeenReactiveDecoratedManuallyComponent } from './components';
+
+
+const mixNormalPropertyComponent = `
+<template>
+  <p>{{this.#text}}</p>
+</template>
+<script>
+  export default class CustomElement extends HTMLElement {
+    #text = '';
+    data = {};
+  }
+</script>
+`;
+
+const useObjectPropertyComponent = `
+<template>
+  <p>{{this.data.name}}</p>
+  <p>{{this.arr[0]}}</p>
+  <p>{{this.nestedData.obj1.obj2.age}}</p>
+</template>
+<script>
+  export default class CustomElement extends HTMLElement {
+    data = {};
+    arr = [];
+    nestedData = {
+      obj1: {
+        obj2: {
+          age: 10
+        }
+      }
+    }
+  }
+</script>
+`;
+
+const useOutsideVariableComponent = `
+<template>
+  <p>{{outsideName}}</p>
+  <p>{{this.insideName}}</p>
+</template>
+<script>
+  import outsideName from './data';
+  export default class CustomElement extends HTMLElement {
+    insideName = '';
+  }
+</script>
+`;
+
+const pureComponent = `
+<template>
+  <p>hello</p>
+</template>
+<script>
+export default class CustomElement extends HTMLElement {}
+</script>`;
+
+describe('reactive decorator', () => {
+
+  test('It should not add reactive decorator when there is no reactive variable in template', () => {
+    const { descriptor } = parse(useReactiveComponent);
+    const result = compileScript(descriptor);
+
+    expect(result.content).toEqual(`import { reactive, customElement as __customElement } from 'pwc';
+@__customElement("custom-element")
+export default class CustomElement extends HTMLElement {
+  @reactive
+  accessor name = '';
+
+  get template() {
+    return ["\\n  <p>hello</p>\\n", []];
+  }
+
+}`);
+  });
+
+  test('It should add reactive decorator when there is reactive variable in template even if reactive decorator has been used manually', () => {
+    const { descriptor } = parse(useReactiveWithAutoAddReactiveComponent);
+    const result = compileScript(descriptor);
+
+    expect(result.content).toEqual(`import { reactive, customElement as __customElement, reactive as __reactive } from 'pwc';
+@__customElement("custom-element")
+export default class CustomElement extends HTMLElement {
+  @__reactive
+  accessor #name = '';
+  @reactive
+  accessor data = '';
+
+  get template() {
+    return ["\\n  <p><!--?pwc_t--></p>\\n", [this.#name]];
+  }
+
+}`);
+  });
+
+
+  test('It should not add reactive decorator when the variable has been reactive decorated manually', () => {
+    const { descriptor } = parse(reactiveHasBeenReactiveDecoratedManuallyComponent);
+    const result = compileScript(descriptor);
+
+    expect(result.content).toEqual(`import { reactive, customElement as __customElement } from 'pwc';
+@__customElement(\"custom-element\")
+export default class CustomElement extends HTMLElement {
+  @reactive
+  accessor #name = '';
+
+  get template() {
+    return [\"\\n  <p><!--?pwc_t--></p>\\n\", [this.#name]];
+  }
+
+}`);
+  });
+
+  test('It should not add @reactive decorator to normal property', () => {
+    const { descriptor } = parse(mixNormalPropertyComponent);
+    const result = compileScript(descriptor);
+
+    expect(result.content).toEqual(`import { customElement as __customElement, reactive as __reactive } from "pwc";
+@__customElement("custom-element")
+export default class CustomElement extends HTMLElement {
+  @__reactive
+  accessor #text = '';
+  data = {};
+
+  get template() {
+    return ["\\n  <p><!--?pwc_t--></p>\\n", [this.#text]];
+  }
+
+}`);
+  });
+
+  test('It should add @reactive decorator to object property', () => {
+    const { descriptor } = parse(useObjectPropertyComponent);
+    const result = compileScript(descriptor);
+
+    expect(result.content).toEqual(`import { customElement as __customElement, reactive as __reactive } from "pwc";
+@__customElement("custom-element")
+export default class CustomElement extends HTMLElement {
+  @__reactive
+  accessor data = {};
+  @__reactive
+  accessor arr = [];
+  @__reactive
+  accessor nestedData = {
+    obj1: {
+      obj2: {
+        age: 10
+      }
+    }
+  };
+
+  get template() {
+    return ["\\n  <p><!--?pwc_t--></p>\\n  <p><!--?pwc_t--></p>\\n  <p><!--?pwc_t--></p>\\n", [this.data.name, this.arr[0], this.nestedData.obj1.obj2.age]];
+  }
+
+}`);
+  });
+
+  test('It should not add @reactive decorator to outside data', () => {
+    const { descriptor } = parse(useOutsideVariableComponent);
+    const result = compileScript(descriptor);
+
+    expect(result.content).toEqual(`import { customElement as __customElement, reactive as __reactive } from "pwc";
+import outsideName from './data';
+@__customElement("custom-element")
+export default class CustomElement extends HTMLElement {
+  @__reactive
+  accessor insideName = '';
+
+  get template() {
+    return ["\\n  <p><!--?pwc_t--></p>\\n  <p><!--?pwc_t--></p>\\n", [outsideName, this.insideName]];
+  }
+
+}`);
+  });
+
+  test('It should not import reactive with pure component', () => {
+    const { descriptor } = parse(pureComponent);
+    const result = compileScript(descriptor);
+
+    expect(result.content).toEqual(`import { customElement as __customElement } from \"pwc\";
+@__customElement(\"custom-element\")
+export default class CustomElement extends HTMLElement {
+  get template() {
+    return [\"\\n  <p>hello</p>\\n\", []];
+  }
+
+}`);
+  });
+});

--- a/packages/pwc-compiler/build.config.ts
+++ b/packages/pwc-compiler/build.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   sourceMaps: 'inline',
 
   transform: {
+    formats: ['cjs', 'esm', 'es2017'],
     excludes: ['**/__tests__/**'],
   },
 });

--- a/packages/pwc-compiler/package.json
+++ b/packages/pwc-compiler/package.json
@@ -4,12 +4,13 @@
   "author": "Rax Team",
   "homepage": "https://github.com/raxjs/pwc#readme",
   "license": "MIT",
-  "main": "esm/index.js",
+  "main": "cjs/index.js",
   "module": "esm/index.js",
   "exports": {
     ".": {
       "es": "./esm/index.js",
       "es2017": "./es2017/index.js",
+      "require": "./cjs/index.js",
       "default": "./esm/index.js"
     },
     "./compileTemplateInRuntime": {

--- a/packages/pwc-compiler/src/transform/autoAddAccessor.ts
+++ b/packages/pwc-compiler/src/transform/autoAddAccessor.ts
@@ -1,9 +1,10 @@
 import type { File } from '@babel/types';
 import * as t from '@babel/types';
 import babelTraverse from '@babel/traverse';
+import { REACTIVE_DECORATOR } from './autoAddReactiveDecorator';
 
 function isIncludeReactiveDecorator(decorators: Array<t.Decorator>): boolean {
-  return decorators.some(decorator => t.isIdentifier(decorator.expression) && decorator.expression.name === '__reactive');
+  return decorators.some(decorator => t.isIdentifier(decorator.expression) && decorator.expression.name === REACTIVE_DECORATOR);
 }
 
 function createClassAccessorPropertyFromClassProperty(node: t.ClassProperty | t.ClassPrivateProperty) {

--- a/packages/pwc-compiler/src/transform/autoAddAccessor.ts
+++ b/packages/pwc-compiler/src/transform/autoAddAccessor.ts
@@ -3,7 +3,7 @@ import * as t from '@babel/types';
 import babelTraverse from '@babel/traverse';
 
 function isIncludeReactiveDecorator(decorators: Array<t.Decorator>): boolean {
-  return decorators.some(decorator => t.isIdentifier(decorator.expression) && decorator.expression.name === 'reactive');
+  return decorators.some(decorator => t.isIdentifier(decorator.expression) && decorator.expression.name === '__reactive');
 }
 
 function createClassAccessorPropertyFromClassProperty(node: t.ClassProperty | t.ClassPrivateProperty) {

--- a/packages/pwc-compiler/src/transform/autoAddCustomElementDecorator.ts
+++ b/packages/pwc-compiler/src/transform/autoAddCustomElementDecorator.ts
@@ -3,6 +3,8 @@ import * as t from '@babel/types';
 import babelTraverse from '@babel/traverse';
 import { toDash } from '../utils';
 
+const CUSTOM_ELEMENT_DECORATOR = '__customElement';
+
 // e.g. @customElement('__custom-component')
 function createCallExpressionDecorator(decorator: string, argument) {
   return t.decorator(t.callExpression(t.identifier(decorator), [t.stringLiteral(argument)]));
@@ -19,7 +21,7 @@ export default function autoAddCustomElementDecorator(ast: File): boolean {
         if (!declaration.decorators || declaration.decorators.length === 0) {
           const { id } = declaration;
           // TODO:component name
-          declaration.decorators = [createCallExpressionDecorator('__customElement', toDash(id.name))];
+          declaration.decorators = [createCallExpressionDecorator(CUSTOM_ELEMENT_DECORATOR, toDash(id.name))];
         } else {
           shouldAutoAddCustomElementDecorator = false;
         }

--- a/packages/pwc-compiler/src/transform/autoAddCustomElementDecorator.ts
+++ b/packages/pwc-compiler/src/transform/autoAddCustomElementDecorator.ts
@@ -3,14 +3,15 @@ import * as t from '@babel/types';
 import babelTraverse from '@babel/traverse';
 import { toDash } from '../utils';
 
-// e.g. @customElement('custom-component')
+// e.g. @customElement('__custom-component')
 function createCallExpressionDecorator(decorator: string, argument) {
   return t.decorator(t.callExpression(t.identifier(decorator), [t.stringLiteral(argument)]));
 }
 
-export default function autoAddCustomElementDecorator(ast: File): void {
+export default function autoAddCustomElementDecorator(ast: File): boolean {
+  let shouldAutoAddCustomElementDecorator = true;
   babelTraverse(ast, {
-    // Add @customElement('custom-component') for class
+    // Add @__customElement('custom-component') for class
     ExportDefaultDeclaration(path) {
       const { node } = path;
       const { declaration } = node;
@@ -18,9 +19,12 @@ export default function autoAddCustomElementDecorator(ast: File): void {
         if (!declaration.decorators || declaration.decorators.length === 0) {
           const { id } = declaration;
           // TODO:component name
-          declaration.decorators = [createCallExpressionDecorator('customElement', toDash(id.name))];
+          declaration.decorators = [createCallExpressionDecorator('__customElement', toDash(id.name))];
+        } else {
+          shouldAutoAddCustomElementDecorator = false;
         }
       }
     },
   });
+  return shouldAutoAddCustomElementDecorator;
 }

--- a/packages/pwc-compiler/src/transform/autoAddReactiveDecorator.ts
+++ b/packages/pwc-compiler/src/transform/autoAddReactiveDecorator.ts
@@ -88,7 +88,7 @@ export default function autoAddReactiveDecorator(ast: File, values: ValueDescrip
       const { node } = path;
       if (t.isIdentifier(node.key) && classPropertyUsedInTemplate.includes(node.key.name)) {
         if (!node.decorators || node.decorators.length === 0) {
-          node.decorators = [createIdentifierDecorator('reactive')];
+          node.decorators = [createIdentifierDecorator('__reactive')];
           hasReactiveVariableInTemplate = true;
         }
       }
@@ -98,7 +98,7 @@ export default function autoAddReactiveDecorator(ast: File, values: ValueDescrip
       const { node } = path;
       if (t.isPrivateName(node.key) && classPropertyUsedInTemplate.includes(`#${node.key.id.name}`)) {
         if (!node.decorators || node.decorators.length === 0) {
-          node.decorators = [createIdentifierDecorator('reactive')];
+          node.decorators = [createIdentifierDecorator('__reactive')];
           hasReactiveVariableInTemplate = true;
         }
       }

--- a/packages/pwc-compiler/src/transform/autoAddReactiveDecorator.ts
+++ b/packages/pwc-compiler/src/transform/autoAddReactiveDecorator.ts
@@ -5,6 +5,8 @@ import * as babelParser from '@babel/parser';
 import type { ValueDescriptor } from '../compileTemplate';
 import { isEventName } from '../utils';
 
+export const REACTIVE_DECORATOR = '__reactive';
+
 const THIS_EXPRESSION_REG = /^this[.|[]/;
 
 function isThisExpression(expression: string): boolean {
@@ -88,7 +90,7 @@ export default function autoAddReactiveDecorator(ast: File, values: ValueDescrip
       const { node } = path;
       if (t.isIdentifier(node.key) && classPropertyUsedInTemplate.includes(node.key.name)) {
         if (!node.decorators || node.decorators.length === 0) {
-          node.decorators = [createIdentifierDecorator('__reactive')];
+          node.decorators = [createIdentifierDecorator(REACTIVE_DECORATOR)];
           hasReactiveVariableInTemplate = true;
         }
       }
@@ -98,7 +100,7 @@ export default function autoAddReactiveDecorator(ast: File, values: ValueDescrip
       const { node } = path;
       if (t.isPrivateName(node.key) && classPropertyUsedInTemplate.includes(`#${node.key.id.name}`)) {
         if (!node.decorators || node.decorators.length === 0) {
-          node.decorators = [createIdentifierDecorator('__reactive')];
+          node.decorators = [createIdentifierDecorator(REACTIVE_DECORATOR)];
           hasReactiveVariableInTemplate = true;
         }
       }

--- a/packages/pwc-compiler/src/transform/autoInjectImportPWC.ts
+++ b/packages/pwc-compiler/src/transform/autoInjectImportPWC.ts
@@ -2,59 +2,45 @@ import type { File } from '@babel/types';
 import * as t from '@babel/types';
 import babelTraverse from '@babel/traverse';
 
-// e.g. import { reactive, customElement } from 'pwc'
+interface injectImportPWCDescriptor {
+  customElement: boolean;
+  reactive: boolean;
+}
+
+// e.g. import { reactive as __reactive, customElement as __customElement } from 'pwc'
 function createImportDeclaration(source: string, imported: Array<string>) {
-  const specifiers = imported.map(im => t.importSpecifier(t.identifier(im), t.identifier(im)));
+  const specifiers = imported.map(im => t.importSpecifier(t.identifier(`__${im}`), t.identifier(im)));
   return t.importDeclaration(specifiers, t.stringLiteral(source));
 }
 
-// create import specifier expression, e.g. the { reactive } of import { reactive } from 'pwc'
+// create import specifier expression, e.g. the { reactive as __reactive } of import { reactive } from 'pwc'
 function createImportSpecifier(importedName) {
-  return t.importSpecifier(t.identifier(importedName), t.identifier(importedName));
+  return t.importSpecifier(t.identifier(`__${importedName}`), t.identifier(importedName));
 }
 
-// customElement must be imported
-// reactive should be imported if shouldImportReactive is true
-const shouldImportedFromPWC = ['customElement', 'reactive'];
-
-export default function autoInjectImportPWC(ast: File, shouldImportReactive: boolean): void {
+export default function autoInjectImportPWC(ast: File, importDescriptor: injectImportPWCDescriptor): void {
+  const importSpecifiers = Object.keys(importDescriptor).filter(specifier => importDescriptor[specifier]);
   babelTraverse(ast, {
     Program(path) {
       let hasImportPWC = false;
-      const hasImportedFromPWC = shouldImportedFromPWC.reduce((prev, cur) => {
-        return Object.assign(prev, {
-          [cur]: false,
-        });
-      }, {});
       path.traverse({
         ImportDeclaration(path) {
           const { node } = path;
-          // has imported pwc manually
-          // should check whether specifiers have been imported
+          // Has imported pwc manually
+          // Should check whether specifiers have been imported
           if (t.isLiteral(node.source) && node.source.value === 'pwc') {
             hasImportPWC = true;
-            node.specifiers.forEach(specifier => {
-              if (t.isImportSpecifier(specifier) && t.isIdentifier(specifier.imported)) {
-                const importedName = specifier.imported.name;
-                hasImportedFromPWC[importedName] = true;
-              }
-            });
-            Object.entries(hasImportedFromPWC).forEach(([importedName, hasImported]) => {
-              if (!hasImported) {
-                if (importedName !== 'reactive' || shouldImportReactive) {
-                  node.specifiers.push(createImportSpecifier(importedName));
-                }
-              }
+            importSpecifiers.forEach((importedName) => {
+              node.specifiers.push(createImportSpecifier(importedName));
             });
           }
         },
       });
 
-      // not import pwc in original code
-      // should generate import declaration
+      // Not import pwc in original code
+      // Should generate import declaration
       if (!hasImportPWC) {
         const { node } = path;
-        const importSpecifiers = shouldImportReactive ? shouldImportedFromPWC : shouldImportedFromPWC.slice(0, 1);
         const importDeclaration = createImportDeclaration('pwc', importSpecifiers);
         node.body.unshift(importDeclaration);
       }

--- a/packages/pwc-compiler/src/transform/index.ts
+++ b/packages/pwc-compiler/src/transform/index.ts
@@ -16,12 +16,17 @@ export default function transformScript(ast: File, {
   templateString,
   values,
 }: TransformScriptOptions): void {
-  autoAddCustomElementDecorator(ast);
+  let shouldImportCustomElement = true;
   let shouldImportReactive = false;
+
+  shouldImportCustomElement = autoAddCustomElementDecorator(ast);
   if (templateString !== null) {
     shouldImportReactive = autoAddReactiveDecorator(ast, values);
     autoAddAccessor(ast);
     genGetTemplateMethod(ast, { templateString, values });
   }
-  autoInjectImportPWC(ast, shouldImportReactive);
+  autoInjectImportPWC(ast, {
+    customElement: shouldImportCustomElement,
+    reactive: shouldImportReactive,
+  });
 }

--- a/packages/rollup-plugin-pwc/src/pwc.ts
+++ b/packages/rollup-plugin-pwc/src/pwc.ts
@@ -48,11 +48,13 @@ function genScriptCode(descriptor: SFCDescriptor, pluginContext: TransformPlugin
 function genStyleCode(descriptor: SFCDescriptor) {
   // TODO: css scoped
   let styleCode = '';
-  const src = descriptor.filename;
-  const attrsQuery = attrsToQuery(descriptor.style.attrs, 'css');
-  const query = `?pwc&type=style${attrsQuery}`;
-  const styleRequest = JSON.stringify(src + query);
-  styleCode += `\nimport ${styleRequest}`;
+  if (descriptor.style) {
+    const src = descriptor.filename;
+    const attrsQuery = attrsToQuery(descriptor.style.attrs, 'css');
+    const query = `?pwc&type=style${attrsQuery}`;
+    const styleRequest = JSON.stringify(src + query);
+    styleCode += `\nimport ${styleRequest}`;
+  }
   return styleCode;
 }
 


### PR DESCRIPTION
To avoid name conflict, variables imported from pwc are renamed with "__" prefix: 

```js
import { reactive as __reactive, customElement as __customElement } from 'pwc';
```